### PR TITLE
A faster solution for 2.add two numbsers

### DIFF
--- a/DP/BestTimeBuySellStock.swift
+++ b/DP/BestTimeBuySellStock.swift
@@ -8,16 +8,16 @@
 
 class BestTimeBuySellStock {
     func maxProfit(prices: [Int]) -> Int {
-        guard prices.count >= 2 else {
-            return 0
-        }
-    
+        guard prices.count > 0 else {return 0}
         var maxProfit = 0
-        var lowest = prices[0]
+        var buyDay = 0
         
-        for price in prices {
-            maxProfit = max(maxProfit, price - lowest)
-            lowest = min(lowest, price)
+        for i in 1 ..< prices.count {
+            let profit = prices[i] - prices[buyDay]
+            if profit < 0 {
+                buyDay = i
+            }
+            maxProfit = max(profit, maxProfit)
         }
         
         return maxProfit

--- a/Math/AddTwoNumbers.swift
+++ b/Math/AddTwoNumbers.swift
@@ -16,26 +16,18 @@
 
 class AddTwoNumbers {
     func addTwoNumbers(l1: ListNode?, _ l2: ListNode?) -> ListNode? {
-        var carry = 0, l1 = l1, l2 = l2
-        let dummy = ListNode(0)
-        var node = dummy
+        guard let l1 = l1 else {return l2}
+        guard let l2 = l2 else {return l1}
         
-        while l1 != nil || l2 != nil || carry != 0 {
-            if l1 != nil {
-                carry += l1!.val
-                l1 = l1!.next
-            }
-            if l2 != nil {
-                carry += l2!.val
-                l2 = l2!.next
-            }
-            
-            node.next = ListNode(carry % 10)
-            node = node.next!
-            
-            carry = carry / 10
+        let outputNode = ListNode((l1.val + l2.val)%10)
+        if l1.val + l2.val > 9 {
+            outputNode.next = addTwoNumbers(addTwoNumbers(l1.next, l2.next),
+                                            ListNode(1))
+        } else {
+            outputNode.next = addTwoNumbers(l1.next, l2.next)
         }
         
-        return dummy.next 
+        
+        return outputNode
     }
 }


### PR DESCRIPTION
Runtime: 52 ms, faster than 97.77% of Swift online submissions for Add Two Numbers.
Memory Usage: 18.9 MB, less than 28.75% of Swift online submissions for Add Two Numbers.