### PR TITLE
Fix `Fatal error: Index out of range` issue when matrix is empty And one typo

### DIFF
--- a/Array/NumMatrix.swift
+++ b/Array/NumMatrix.swift
@@ -7,9 +7,18 @@
 
 class NumMatrix {
     fileprivate var sum: [[Int]]
+    fileprivate var m: Int
+    fileprivate var n: Int
     
     init(_ matrix: [[Int]]) {
-        let m = matrix.count, n = matrix[0].count
+        m = matrix.count
+        
+        if m == 0 {
+            n = 0
+        } else {
+            n = matrix[0].count
+        }
+        
         sum = Array(repeating: Array(repeating: 0, count: n), count: m)
         
         for i in 0..<m {

--- a/String/ValidPalindrome.swift
+++ b/String/ValidPalindrome.swift
@@ -33,7 +33,7 @@ class ValidPalindrome {
 }
 
 extension Character {
-    var isValid: Bool {
+    var isAlphanumeric: Bool {
         return isLetter || isNumber
     }
 }


### PR DESCRIPTION
The old version of the solution to `304. Range Sum Query 2D - Immutable` didn't cover the case that the input matrix is empty. 
When the input matrix is empty, the result will be "Fatal error: Index out of range".