### PR TITLE
fix EvaluateDivision.swift error: wrong answer

### DIFF
--- a/BFS/EvaluateDivision.swift
+++ b/BFS/EvaluateDivision.swift
@@ -75,9 +75,7 @@ class EvaluateDivision {
                 qStrs.append(str)
                 qVals.append(currentVal * val)
             }
-
-
-            rest.append(-1.0)
         }
+        rest.append(-1.0)
     }
 }


### PR DESCRIPTION
Wrong place to append `-1` to result.